### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
+# Enable 3.7 without globally enabling dist: xenial for other build jobs
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial
 
 install:
   - "pip install -e .[test]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - "pip install pycodestyle"
   - "pip install pyflakes"
   - "pip install pylint"
-  - "if [ \"${TRAVIS_PYTHON_VERSION}\" == '3.6' ]; then pip install sphinx; fi"
+  - "if [ \"${TRAVIS_PYTHON_VERSION}\" == '3.7' ]; then pip install sphinx; fi"
 
 script:
   - "coverage run --source=validation setup.py test"
@@ -23,7 +23,7 @@ after_success:
   - "coveralls"
 
 before_deploy:
-  - "if [ \"${TRAVIS_PYTHON_VERSION}\" == '3.6' ]; then make -C docs html; fi"
+  - "if [ \"${TRAVIS_PYTHON_VERSION}\" == '3.7' ]; then make -C docs html; fi"
 
 deploy:
   - provider: pages
@@ -33,7 +33,7 @@ deploy:
     github_token: "$GITHUB_TOKEN"
     on:
       branch: "master"
-      condition: "\"${TRAVIS_PYTHON_VERSION}\" = '3.6'"
+      condition: "\"${TRAVIS_PYTHON_VERSION}\" = '3.7'"
   - provider: pypi
     distributions: "sdist --formats=zip"
     user: "bwhmather-travis"
@@ -41,4 +41,4 @@ deploy:
       secure: "rLlDjRwGY41G4DGU3g54RRkigMRHlFkffckVL+UpgRLaIWbTvvMfwDZvViMNsABxKS9Mwgf/D3Xls+DvimMY5is9l2bMQsW9MgQN+icnZFGgY+dnQD9ylSWcxn5U+/P0BTz1WIY4cA41Rjqv0aE23FKwkUYgfkdvYz51IrcvMbrvoo7LgTAPgF43r1LJAysv5A0Q4xdiKrl3d/9KfiDAS9PA6CXWMj7EXNzoUEl8UoycUwKsTx7hHthmsQrHIBPb7oB0xuKo5UtCYHlAXvIfD7VCbg4O5kLVb/f4m+Uo0eRpLw3RMtV/VJ/jK6UROZgixSP0Dryg9uP9/S3Ei/XgWnpWX4JRQ9ZQZW3tvo6YvQL/uVwsOpvbwhTJuIh+HUHGyVUwZvMsL2x53qnroJHffhvdnKji5p8ITJW6YPFovoZMktl9PLr/4ZprmY/pYFdJKMjOJuOpRTBctAmVX3d20oR9TWsliHb4D2CDOukmWT1iw9ogJwIDsGxqHt5GC/Rfe6Zb7k+GogMASXwGmw/D1n2SKbayryC+ngWoR7TEFdG78K0vCciu8Faq+sOeb8NCJl/cxBiOPvwD3LDnH5OSB/HM4sGF9pU2XnTUv41osP1wsPUCB7t61vj+J4sV0pgfvFHKzRkgZV5qCwbxq0DyFgmJqESPjs7WLQAI2sU3MHA="
     on:
       branch: "master"
-      condition: "\"${TRAVIS_PYTHON_VERSION}\" = '3.6'"
+      condition: "\"${TRAVIS_PYTHON_VERSION}\" = '3.7'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 install:
   - "pip install -e .[test]"

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,pycodestyle,pyflakes,pylint2,pylint3,mypy2,mypy3
+envlist = py27,py34,py35,py36,py37,pycodestyle,pyflakes,pylint2,pylint3,mypy2,mypy3
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ commands =
     python setup.py test
 
 [testenv:pycodestyle]
-basepython = python3.6
+basepython = python3.7
 deps =
     pycodestyle
 skip_install = True
@@ -14,7 +14,7 @@ commands =
     pycodestyle validation setup.py
 
 [testenv:pyflakes]
-basepython = python3.6
+basepython = python3.7
 deps =
     pyflakes
 skip_install = True
@@ -31,7 +31,7 @@ commands =
     pylint -E validation setup.py
 
 [testenv:pylint3]
-basepython = python3.6
+basepython = python3.7
 deps =
     pylint
 extras=
@@ -40,7 +40,7 @@ commands =
     pylint -E validation setup.py
 
 [testenv:mypy2]
-basepython = python3.6
+basepython = python3.7
 deps =
     mypy
 extras =
@@ -49,7 +49,7 @@ commands =
     mypy --py2 validation
 
 [testenv:mypy3]
-basepython = python3.6
+basepython = python3.7
 deps =
     mypy
 extras =

--- a/validation/string.py
+++ b/validation/string.py
@@ -7,7 +7,7 @@ import re
 try:
     from typing.re import Pattern as _pattern_type
 except ImportError:  # pragma: no cover
-    _pattern_type = re._pattern_type
+    _pattern_type = re._pattern_type  # pylint: disable=no-member
 
 import six
 


### PR DESCRIPTION
Includes #68.

Resolves #67.

Python 3.7 requires Xenial on Travis CI.