### PR TITLE
 Drop support for EOL Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 python:
   - "2.7"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"
@@ -11,15 +10,15 @@ install:
   - "pip install -e .[test]"
   - "pip install coveralls"
   - "pip install pycodestyle"
-  - "if [ \"${TRAVIS_PYTHON_VERSION}\" != '2.6' ]; then pip install pyflakes; fi"
-  - "if [ \"${TRAVIS_PYTHON_VERSION}\" != '2.6' ]; then pip install pylint; fi"
+  - "pip install pyflakes"
+  - "pip install pylint"
   - "if [ \"${TRAVIS_PYTHON_VERSION}\" == '3.6' ]; then pip install sphinx; fi"
 
 script:
   - "coverage run --source=validation setup.py test"
   - "pycodestyle validation setup.py"
-  - "if [ \"${TRAVIS_PYTHON_VERSION}\" != '2.6' ]; then pyflakes validation setup.py; fi"
-  - "if [ \"${TRAVIS_PYTHON_VERSION}\" != '2.6' ]; then pylint -E validation setup.py; fi"
+  - "pyflakes validation setup.py"
+  - "pylint -E validation setup.py"
 
 after_success:
   - "coveralls"

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Python Validation
 
 .. begin-docs
 
-A simple python library containing functions that check python values.
+A simple Python library containing functions that check Python values.
 It is intended to make it easy to verify commonly expected pre-conditions on
 arguments to functions.
 
@@ -32,9 +32,9 @@ It can be installed manually using pip.
     $ pip install validation
 
 As this library is a useful tool for cleaning up established codebases, it will
-continue to support python 2.6 and 2.7 for the foreseeable future.
+continue to support Python 2.7 for the foreseeable future.
 The string validation functions are particularly handy for sorting out unicode
-issues in preparation for making the jump to python 3.
+issues in preparation for making the jump to Python 3.
 
 .. end-installation
 
@@ -100,9 +100,9 @@ for email addresses and domain names.
 
 Functions are fairly strict by default.
 ``validate_float``, for example, will reject ``NaN`` unless explicitly allowed.
-On python 2 ``validate_text`` will enforce the use of unicode.
+On Python 2 ``validate_text`` will enforce the use of unicode.
 
-Intended to be mixed with normal python code to perform more complex
+Intended to be mixed with normal Python code to perform more complex
 validation.
 As an example, the library provides no tools to assert that to values are
 mutually exclusive as this requirement is much more clearly expressed with a

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-import sys
-
 from setuptools import setup, find_packages
 
 
@@ -10,8 +8,6 @@ with open('README.rst') as _readme_file:
 tests_require = [
     'pytz',
 ]
-if sys.version_info < (2, 7):
-    tests_require += ['unittest2']
 
 setup(
     name='validation',
@@ -30,7 +26,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=[
         'six >= 1.10, < 2',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
-envlist = py26,py27,py34,py35,py36,pycodestyle,pyflakes,pylint2,pylint3,mypy2,mypy3
+envlist = py27,py34,py35,py36,pycodestyle,pyflakes,pylint2,pylint3,mypy2,mypy3
 
 [testenv]
 commands =
     python setup.py test
-deps =
-    py26: wheel==0.29.0
 
 [testenv:pycodestyle]
 basepython = python3.6

--- a/validation/tests/__init__.py
+++ b/validation/tests/__init__.py
@@ -1,8 +1,4 @@
-import sys
-if sys.version_info < (2, 7):  # pragma: no cover
-    import unittest2 as unittest  # pylint: disable=import-error
-else:
-    import unittest
+import unittest
 
 from . import (
     test_bool,

--- a/validation/tests/test_bool.py
+++ b/validation/tests/test_bool.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from . import unittest
+import unittest
 
 from validation import validate_bool
 

--- a/validation/tests/test_bytes.py
+++ b/validation/tests/test_bytes.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from . import unittest
+import unittest
 
 from validation import validate_bytes
 

--- a/validation/tests/test_date.py
+++ b/validation/tests/test_date.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from . import unittest
+import unittest
 from datetime import date, datetime
 
 from validation import validate_date

--- a/validation/tests/test_datetime.py
+++ b/validation/tests/test_datetime.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from . import unittest
+import unittest
 from datetime import date, datetime
 
 import pytz

--- a/validation/tests/test_float.py
+++ b/validation/tests/test_float.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from . import unittest
+import unittest
 import math
 
 from validation import validate_float

--- a/validation/tests/test_int.py
+++ b/validation/tests/test_int.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from . import unittest
+import unittest
 import sys
 
 import six

--- a/validation/tests/test_list.py
+++ b/validation/tests/test_list.py
@@ -21,7 +21,7 @@ class ValidateListTestCase(unittest.TestCase):
 
     def test_validate_set(self):
         with self.assertRaises(TypeError):
-            validate_list(set([1]), validator=validate_int())
+            validate_list({1}, validator=validate_int())
 
     def test_validate_iterator(self):
         with self.assertRaises(TypeError):

--- a/validation/tests/test_list.py
+++ b/validation/tests/test_list.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from . import unittest
+import unittest
 
 from validation import validate_int, validate_list
 

--- a/validation/tests/test_mapping.py
+++ b/validation/tests/test_mapping.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from . import unittest
+import unittest
 
 from validation import validate_int, validate_text, validate_mapping
 

--- a/validation/tests/test_optional_argument.py
+++ b/validation/tests/test_optional_argument.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from . import unittest
+import unittest
 from copy import copy, deepcopy
 import pickle
 

--- a/validation/tests/test_set.py
+++ b/validation/tests/test_set.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from . import unittest
+import unittest
 
 from validation import validate_int, validate_set
 

--- a/validation/tests/test_set.py
+++ b/validation/tests/test_set.py
@@ -10,15 +10,15 @@ class ValidateSetTestCase(unittest.TestCase):
         validate_set(set())
 
     def test_non_empty_no_validator(self):  # type: () -> None
-        validate_set(set([1, 'string']))
+        validate_set({1, 'string'})
 
     def test_validator_valid(self):  # type: () -> None
-        validate_set(set([1, 2, 3]), validator=validate_int())
+        validate_set({1, 2, 3}, validator=validate_int())
 
     def test_validator_invalid(self):  # type: () -> None
         with self.assertRaises(ValueError):
             validate_set(
-                set([1, 2, 3, -1]),
+                {1, 2, 3, -1},
                 validator=validate_int(min_value=0),
             )
 
@@ -27,17 +27,17 @@ class ValidateSetTestCase(unittest.TestCase):
             validate_set([1], validator=validate_int())
 
     def test_min_len_valid(self):  # type: () -> None
-        validate_set(set([1, 2, 3]), min_length=3)
+        validate_set({1, 2, 3}, min_length=3)
 
     def test_min_len_invalid(self):  # type: () -> None
         with self.assertRaises(ValueError):
-            validate_set(set([1, 2, 3]), min_length=4)
+            validate_set({1, 2, 3}, min_length=4)
 
     def test_max_len_valid(self):  # type: () -> None
-        validate_set(set([1, 2, 3]), max_length=3)
+        validate_set({1, 2, 3}, max_length=3)
 
         with self.assertRaises(ValueError):
-            validate_set(set([1, 2, 3, 4]), max_length=3)
+            validate_set({1, 2, 3, 4}, max_length=3)
 
     def test_not_required(self):  # type: () -> None
         validate_set(None, required=False)
@@ -48,9 +48,9 @@ class ValidateSetTestCase(unittest.TestCase):
 
     def test_closure(self):  # type: () -> None
         validator = validate_set(max_length=3)
-        validator(set([1]))
+        validator({1})
         with self.assertRaises(ValueError):
-            validator(set([1, 2, 3, 4]))
+            validator({1, 2, 3, 4})
 
     def test_repr_1(self):  # type: () -> None
         validator = validate_set(min_length=1, max_length=100)

--- a/validation/tests/test_structure.py
+++ b/validation/tests/test_structure.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from . import unittest
+import unittest
 
 from validation import validate_int, validate_text, validate_structure
 

--- a/validation/tests/test_text.py
+++ b/validation/tests/test_text.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from . import unittest
+import unittest
 import re
 
 from validation import validate_text

--- a/validation/tests/test_tuple.py
+++ b/validation/tests/test_tuple.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from . import unittest
+import unittest
 
 from validation import validate_int, validate_text, validate_tuple
 


### PR DESCRIPTION
Resolves #69.

Python 2.6 is EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.6 | 2008-10-01 | 2013-10-29

Source: https://en.wikipedia.org/wiki/CPython#Version_history

It's also little used. Here's the pip installs for validation from PyPI for December 2018:

| category | percent | downloads |
|----------|--------:|----------:|
|      3.7 |  50.96% |       106 |
|      3.6 |  21.63% |        45 |
|      2.7 |  12.50% |        26 |
| null     |  12.02% |        25 |
|      3.5 |   2.88% |         6 |
| Total    |         |       208 |

Source: `pypistats python_minor --last-month validation`